### PR TITLE
Add product ID, update test

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,6 +55,8 @@ export default class AmazonListScraper {
 
     const title = titleNode.attr('title').trim();
 
+    const productId = titleNode.attr('href').split('/')[2];
+
     if (options.kindleOnly) {
       const subtitle = titleNode.closest('.a-row .a-size-small').text();
       if (!subtitle || subtitle.indexOf(KINDLE_EDITION_TEXT) === -1) {
@@ -75,7 +77,7 @@ export default class AmazonListScraper {
       price = INVALID_PRICE;
     }
 
-    return { title, price, link };
+    return { title, price, productId, link };
   }
 
   static getNextPageUrl($) {

--- a/test/test.js
+++ b/test/test.js
@@ -22,11 +22,12 @@ test('error if url is not found', t => (
 test('return list of items with title, price and link', t => (
   new AmazonListScraper().scrape(testListURL).then((items) => {
     t.is(items.length, 2);
-    const { title, price, link } = items[0];
+    const { title, price, productId, link } = items[0];
     // eslint-disable-next-line no-script-url
     t.is(title, 'JavaScript: The Good Parts: The Good Parts');
     t.true(!isNaN(parseFloat(price)));
     t.true(link.startsWith('https://amzn.com/dp/B0026OR2ZY'));
+    t.is(productId, 'B0026OR2ZY');
     t.is(items[1].title, 'Clean Code: A Handbook of Agile Software Craftsmanship');
   })
 ));


### PR DESCRIPTION
I know the info is technically contained in the URL, but I'd rather have a clean payload that gives the customer what it needs rather than do a bunch of string manipulation on receiving the payload.

If you disagree, I'll just use my own fork, otherwise, this works, so I figured I'd just open up the PR.

FYI: wish lists no longer paginate via a "next" link. It's lazy loading (after 23 items, for some reason?), and `cheerio` doesn't support JS execution, so this scraper might be doomed as far as large lists go. I did some googlin' and didn't find anything super useful or I would have incorporated it here. Luckily, my needs are probably suited even if I don't pull the whole wish list.